### PR TITLE
Fix search filter reset during refresh

### DIFF
--- a/index (1).html
+++ b/index (1).html
@@ -104,6 +104,8 @@
         const container = document.getElementById('cards');
         container.innerHTML = '';
         data.forEach(coin => container.appendChild(createCard(coin)));
+        const query = document.getElementById('search').value.toLowerCase();
+        if (query) filterCards(query);
       } catch (error) {
         console.error('Error fetching data:', error);
         document.getElementById('cards').innerHTML = '<p>Failed to load data. Please try again later.</p>';
@@ -121,12 +123,15 @@
         const newTheme = document.body.classList.contains('dark') ? 'dark' : 'light';
         localStorage.setItem('theme', newTheme);
       });
-      document.getElementById('search').addEventListener('input', (e) => {
-        const query = e.target.value.toLowerCase();
+      function filterCards(query) {
         document.querySelectorAll('.card').forEach(card => {
           const text = card.textContent.toLowerCase();
           card.style.display = text.includes(query) ? '' : 'none';
         });
+      }
+
+      document.getElementById('search').addEventListener('input', (e) => {
+        filterCards(e.target.value.toLowerCase());
       });
 
       // Initial data load and interval


### PR DESCRIPTION
## Summary
- keep the search query applied after reloading data from the API

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887d34f81848326bb8e1e75129a58d4