### PR TITLE
Add charts and coin analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Crypto Dashboard
 
-Simple dashboard showing cryptocurrency information.
+Simple dashboard showing cryptocurrency information with small price charts and a fear & greed index.
 
 ## Testing
 

--- a/__tests__/dashboard.test.js
+++ b/__tests__/dashboard.test.js
@@ -1,11 +1,12 @@
-import { createCard } from '../dashboard.js';
+import { createCard, analyzeCoin } from '../dashboard.js';
 
 const sampleCoin = {
   image: 'logo.png',
   name: 'Bitcoin',
   symbol: 'btc',
   current_price: 12345.67,
-  price_change_percentage_24h: 1.23
+  price_change_percentage_24h: 1.23,
+  sparkline_in_7d: { price: [12000, 12500, 13000] }
 };
 
 test('createCard returns a DOM element with expected fields', () => {
@@ -16,4 +17,11 @@ test('createCard returns a DOM element with expected fields', () => {
   expect(card.querySelector('h3').textContent).toBe('Bitcoin (BTC)');
   expect(card.querySelector('.price').textContent).toContain('12,345.67');
   expect(card.querySelector('.change').textContent).toContain('1.23');
+  expect(card.querySelector('.analysis')).not.toBeNull();
+});
+
+test('analyzeCoin provides recommendation data', () => {
+  const result = analyzeCoin(sampleCoin);
+  expect(result).toHaveProperty('recommendation');
+  expect(result).toHaveProperty('percentChange');
 });

--- a/dashboard.js
+++ b/dashboard.js
@@ -1,6 +1,21 @@
 // dashboard.js
 
+export function analyzeCoin(coin) {
+  if (!coin.sparkline_in_7d || !Array.isArray(coin.sparkline_in_7d.price)) {
+    return { percentChange: '0.00', recommendation: 'No data' };
+  }
+  const prices = coin.sparkline_in_7d.price;
+  const first = prices[0];
+  const last = prices[prices.length - 1];
+  const percentChange = ((last - first) / first) * 100;
+  let recommendation = 'Hold';
+  if (percentChange > 5) recommendation = 'Consider selling';
+  else if (percentChange < -5) recommendation = 'Consider buying';
+  return { percentChange: percentChange.toFixed(2), recommendation };
+}
+
 export function createCard(coin) {
+  const analysis = analyzeCoin(coin);
   const card = document.createElement('div');
   card.className = 'card';
   card.innerHTML = `
@@ -10,12 +25,53 @@ export function createCard(coin) {
     </div>
     <div class="price">Price: $${coin.current_price.toLocaleString()}</div>
     <div class="change">24h: ${coin.price_change_percentage_24h.toFixed(2)}%</div>
+    <canvas class="chart" width="200" height="100"></canvas>
+    <div class="analysis">7d change: ${analysis.percentChange}% - ${analysis.recommendation}</div>
   `;
+
+  const canvas = card.querySelector('canvas');
+  if (typeof Chart !== 'undefined' && coin.sparkline_in_7d) {
+    renderChart(canvas.getContext('2d'), coin.sparkline_in_7d.price);
+  }
   return card;
 }
 
+function renderChart(ctx, prices) {
+  new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels: prices.map((_, i) => i),
+      datasets: [{
+        data: prices,
+        borderColor: '#3e95cd',
+        borderWidth: 1,
+        pointRadius: 0,
+        fill: false
+      }]
+    },
+    options: {
+      responsive: false,
+      plugins: { legend: { display: false } },
+      scales: { x: { display: false }, y: { display: false } }
+    }
+  });
+}
+
+async function fetchFearGreed() {
+  try {
+    const res = await fetch('https://api.alternative.me/fng/');
+    if (!res.ok) throw new Error('API error');
+    const { data } = await res.json();
+    const fng = data[0];
+    document.getElementById('fear-greed').textContent =
+      `Fear & Greed Index: ${fng.value} (${fng.value_classification})`;
+  } catch (e) {
+    document.getElementById('fear-greed').textContent = 'Fear & Greed Index unavailable';
+  }
+}
+
 const coins = ['cronos','bitcoin','ripple','ethereum','cardano','hedera-hashgraph','loaded-lions'];
-const apiUrl = 'https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&ids=' + coins.join(',') + '&order=market_cap_desc&per_page=7&page=1&sparkline=false';
+const apiUrl = 'https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&ids=' + coins.join(',') + '&order=market_cap_desc&per_page=7&page=1&sparkline=true';
 
 async function fetchData() {
   try {
@@ -25,6 +81,7 @@ async function fetchData() {
     const container = document.getElementById('cards');
     container.innerHTML = '';
     data.forEach(coin => container.appendChild(createCard(coin)));
+    fetchFearGreed();
   } catch (error) {
     console.error('Error fetching data:', error);
     document.getElementById('cards').innerHTML = '<p>Failed to load data. Please try again later.</p>';

--- a/index.html
+++ b/index.html
@@ -74,13 +74,23 @@
       margin-top: 0.5rem;
       font-size: 1rem;
     }
+    .chart {
+      width: 100%;
+      height: 100px;
+    }
+    .analysis {
+      margin-top: 0.5rem;
+      font-size: 0.9rem;
+    }
   </style>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script type="module" src="dashboard.js"></script>
 </head>
 <body>
   <div class="toggle-container">
     <button id="toggle-mode">Toggle Dark/Light</button>
   </div>
+  <div id="fear-greed" style="text-align:center; margin-bottom:1rem;"></div>
   <input type="text" id="search" placeholder="Search coins..." />
   <div id="cards" class="grid"></div>
 </body>


### PR DESCRIPTION
## Summary
- add coin analysis with simple buy/sell suggestions
- include small price charts and a fear & greed index
- fetch sparkline data, render charts with Chart.js
- update tests for new features

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887d7e105688326b07629f0c46ac4df