### PR TITLE
Add predictive insights and portfolio tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Crypto Dashboard
 
-Simple dashboard showing cryptocurrency information.
+Simple dashboard showing cryptocurrency information with basic predictive
+insights and a lightweight portfolio tracker. Prices are fetched from the
+CoinGecko API and a naive algorithm estimates the next day's price to
+provide a simple buy/sell/hold signal.
 
 ## Testing
 

--- a/index.html
+++ b/index.html
@@ -74,6 +74,14 @@
       margin-top: 0.5rem;
       font-size: 1rem;
     }
+    .prediction, .signal {
+      margin-top: 0.5rem;
+      font-size: 0.9rem;
+    }
+    .portfolio {
+      margin-top: 0.5rem;
+      font-size: 0.9rem;
+    }
   </style>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
   <script type="module" src="dashboard.js"></script>
@@ -83,6 +91,7 @@
     <button id="toggle-mode">Toggle Dark/Light</button>
   </div>
   <div id="fear-greed" style="text-align:center;margin-bottom:1rem;"></div>
+  <div id="net-worth" style="text-align:center;margin-bottom:1rem;font-weight:bold;"></div>
   <input type="text" id="search" placeholder="Search coins..." />
   <div id="cards" class="grid"></div>
 </body>


### PR DESCRIPTION
## Summary
- add prediction, signal, and portfolio styles
- display portfolio value
- generate simple price predictions, buy/sell/hold signals, and track holdings
- note additional features in the README

## Testing
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6887da8356288326ae18e90624955af3