### PR TITLE
Add hourly forecast for coin prices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/__tests__/dashboard.test.js
+++ b/__tests__/dashboard.test.js
@@ -1,4 +1,4 @@
-import { createCard } from '../dashboard.js';
+import { createCard, generateHourlyPredictions } from '../dashboard.js';
 
 const sampleCoin = {
   image: 'logo.png',
@@ -16,4 +16,11 @@ test('createCard returns a DOM element with expected fields', () => {
   expect(card.querySelector('h3').textContent).toBe('Bitcoin (BTC)');
   expect(card.querySelector('.price').textContent).toContain('12,345.67');
   expect(card.querySelector('.change').textContent).toContain('1.23');
+});
+
+test('generateHourlyPredictions returns 24 hourly entries', () => {
+  const list = generateHourlyPredictions(100, 200);
+  expect(list).toHaveLength(24);
+  expect(list[0].price).toBeCloseTo(100 + (200 - 100) * (1 / 24));
+  expect(list[23].price).toBeCloseTo(200);
 });

--- a/dashboard.js
+++ b/dashboard.js
@@ -77,6 +77,38 @@ function addInsights(card, predicted, current) {
   card.appendChild(signalEl);
 }
 
+export function generateHourlyPredictions(current, predicted) {
+  const results = [];
+  const now = new Date();
+  for (let i = 1; i <= 24; i++) {
+    const time = new Date(now.getTime() + i * 60 * 60 * 1000);
+    const price = current + (predicted - current) * (i / 24);
+    results.push({ time, price });
+  }
+  return results;
+}
+
+function addHourlyForecast(card, predictions) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'hourly-forecast';
+  const title = document.createElement('div');
+  title.textContent = 'Hourly Forecast:';
+  wrapper.appendChild(title);
+  const list = document.createElement('ul');
+  predictions.forEach(p => {
+    const li = document.createElement('li');
+    const timeStr = p.time.toLocaleTimeString(undefined, {
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    });
+    li.textContent = `${timeStr}: $${p.price.toFixed(2)}`;
+    list.appendChild(li);
+  });
+  wrapper.appendChild(list);
+  card.appendChild(wrapper);
+}
+
 function addPortfolio(card, coin, updateNetWorth) {
   const key = `holdings_${coin.id}`;
   const stored = parseFloat(localStorage.getItem(key)) || 0;
@@ -134,6 +166,8 @@ async function fetchData() {
         renderChart(card, history);
         const predicted = predictPrice(history);
         addInsights(card, predicted, coin.current_price);
+        const hourly = generateHourlyPredictions(coin.current_price, predicted);
+        addHourlyForecast(card, hourly);
       } catch (err) {
         console.error('Error rendering chart:', err);
       }

--- a/index.html
+++ b/index.html
@@ -82,6 +82,18 @@
       margin-top: 0.5rem;
       font-size: 0.9rem;
     }
+    .hourly-forecast {
+      margin-top: 0.5rem;
+      font-size: 0.8rem;
+    }
+    .hourly-forecast ul {
+      list-style: none;
+      padding-left: 0;
+      margin: 0;
+    }
+    .hourly-forecast li {
+      line-height: 1.4;
+    }
   </style>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
   <script type="module" src="dashboard.js"></script>


### PR DESCRIPTION
## Summary
- predict hourly price over the next day
- show hourly forecast on each card
- style hourly forecast list
- test hourly prediction logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887de4902948326925800f7a1b83be7