### PR TITLE
Add hourly forecast feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Simple dashboard showing cryptocurrency information with basic predictive
 insights and a lightweight portfolio tracker. Prices are fetched from the
-CoinGecko API and a naive algorithm estimates the next day's price to
-provide a simple buy/sell/hold signal.
+CoinGecko API and a naive algorithm estimates future prices. Each coin card
+now displays a 24‑hour forecast table using Pacific Standard Time.
 
 ## Testing
 

--- a/__tests__/dashboard.test.js
+++ b/__tests__/dashboard.test.js
@@ -1,4 +1,4 @@
-import { createCard } from '../dashboard.js';
+import { createCard, generateHourlyPredictions } from '../dashboard.js';
 
 const sampleCoin = {
   image: 'logo.png',
@@ -16,4 +16,13 @@ test('createCard returns a DOM element with expected fields', () => {
   expect(card.querySelector('h3').textContent).toBe('Bitcoin (BTC)');
   expect(card.querySelector('.price').textContent).toContain('12,345.67');
   expect(card.querySelector('.change').textContent).toContain('1.23');
+});
+
+test('generateHourlyPredictions returns 24 entries', () => {
+  const list = generateHourlyPredictions(10, 12);
+  expect(list).toHaveLength(24);
+  const first = list[0];
+  const last = list[23];
+  expect(last.price).toBeCloseTo(12);
+  expect(first.price).toBeGreaterThan(10);
 });


### PR DESCRIPTION
## Summary
- add hourly forecast generation
- show hourly forecast table in each coin card
- document new feature in README
- test hourly prediction helper

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6887de4902948326925800f7a1b83be7